### PR TITLE
add visible highlight color to suggestion window

### DIFF
--- a/themes/Yoncé-color-theme.json
+++ b/themes/Yoncé-color-theme.json
@@ -65,7 +65,7 @@
         "editorSuggestWidget.border": "#FC4384",
         "editorSuggestWidget.foreground": "#FC4384",
         "editorSuggestWidget.highlightForeground": "#777777",
-        "editorSuggestWidget.selectedBackground": "#272727",
+        "editorSuggestWidget.selectedBackground": "#FC43847A",
         "editorWarning.foreground": "#F39B35",
         "editorWhitespace.foreground": "#272727",
         "editorWidget.background": "#272727",


### PR DESCRIPTION
Changes background highlight of suggestion popup window to be visible. Love the theme! Great job!
### Before
![](https://cl.ly/db9fe5972504/Image%202018-11-28%20at%2010.13.12%20AM.png)
### After
![](https://cl.ly/52faec66786f/Image%202018-11-28%20at%209.13.26%20AM.png) 