### PR TITLE
fix suggestion-list active-item highlighting

### DIFF
--- a/themes/Yoncé-color-theme.json
+++ b/themes/Yoncé-color-theme.json
@@ -65,7 +65,7 @@
         "editorSuggestWidget.border": "#FC4384",
         "editorSuggestWidget.foreground": "#FC4384",
         "editorSuggestWidget.highlightForeground": "#777777",
-        "editorSuggestWidget.selectedBackground": "#272727",
+        "editorSuggestWidget.selectedBackground": "#899BBF3A",
         "editorWarning.foreground": "#F39B35",
         "editorWhitespace.foreground": "#272727",
         "editorWidget.background": "#272727",


### PR DESCRIPTION
When VS Code brought up the little dialog to show you autocomplete ("Intellisense" I guess?) suggestions, you couldn't tell which item was selected (if you tried to use the arrow keys to move down the list, for example) since the "active item" background color was the same as the base background color. I changed that background color to follow the pattern of the other dropdown menus.